### PR TITLE
Add python library installation for pwndbg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://medium.com/bugbountywriteup/pwndbg-gef-peda-one-for-all-and-all-for-one-
 ```
 cd ~ && git clone https://github.com/soaringk/gdb-peda-pwndbg-gef.git
 cd ~/gdb-peda-pwndbg-gef
+pip -r ./pwndbg-requirements.txt
 ./install.sh
 ```
 

--- a/pwndbg-requirements.txt
+++ b/pwndbg-requirements.txt
@@ -1,0 +1,15 @@
+future
+isort!=4.3.0
+pip
+psutil>=3.1.0
+pycparser
+pyelftools
+python-ptrace>=0.8
+ROPgadget
+six
+pygments
+capstone==4.0.1
+enum34
+pytest
+testresources
+unicorn==1.0.2rc1


### PR DESCRIPTION
Add a requirements.txt for pwndbg to make sure gdb-pwndbg works correctly after the whole installation if the user haven't installed pwndbg before.