### PR TITLE
Fixed typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://medium.com/bugbountywriteup/pwndbg-gef-peda-one-for-all-and-all-for-one-
 # Installation
 
 ```
-cd ~ && git clone https://github.com/soaringk/gdb-peda-pwndbg-gef.git
+cd ~ && git clone https://github.com/apogiatzis/gdb-peda-pwndbg-gef.git
 cd ~/gdb-peda-pwndbg-gef
 ./install.sh
 ```


### PR DESCRIPTION
Hi, APogiatzis!
```
cd ~ && git clone https://github.com/soaringk/gdb-peda-pwndbg-gef.git
```
The installation command in README.md that would clone another fork of this repository, so the user types this command would make the patch #6 don't work.